### PR TITLE
Package cleanup

### DIFF
--- a/EngagePublish.Build
+++ b/EngagePublish.Build
@@ -95,9 +95,6 @@
         <include name="ReadMe.txt" />
         <include name="**/*.SqlDataProvider"/>
         <include name="**/*.6.dnn"/>
-        <include name="**/View.ascx"/>
-        <include name="**/SearchRedirector.ascx"/>
-        <include name="**/TagCloud.ascx"/>
       </fileset>
     </copy>
     <copy todir="${packageDirectory}/temp/package/bin" flatten="true">


### PR DESCRIPTION
Needed them in the past for old packaging that wouldn't install without at least one control for the module definition.
